### PR TITLE
Set the status correctly if suspendDate or deleteDate are in the past

### DIFF
--- a/src/main/java/net/nitrado/api/services/Service.java
+++ b/src/main/java/net/nitrado/api/services/Service.java
@@ -308,7 +308,7 @@ public abstract class Service {
         GregorianCalendar now = new GregorianCalendar();
         if (deleteDate.before(now) && status != Service.Status.DELETED) {
             status = Status.DELETING;
-        } else if (suspendDate.before(now) && status != Service.Status.SUSPENDED) {
+        } else if (suspendDate.before(now) && status != Service.Status.SUSPENDED && status != Status.DELETED) {
             status = Status.SUSPENDING;
         }
     }

--- a/src/main/java/net/nitrado/api/services/Service.java
+++ b/src/main/java/net/nitrado/api/services/Service.java
@@ -304,7 +304,7 @@ public abstract class Service {
     /**
      * Sets the status correctly if suspendDate or deleteDate are in the past.
      */
-    private void fixServiceStatus() {
+    protected void fixServiceStatus() {
         GregorianCalendar now = new GregorianCalendar();
         if (deleteDate.before(now) && status != Service.Status.DELETED) {
             status = Status.DELETING;

--- a/src/main/java/net/nitrado/api/services/Service.java
+++ b/src/main/java/net/nitrado/api/services/Service.java
@@ -44,7 +44,17 @@ public abstract class Service {
          * The service is deleted.
          */
         @SerializedName("deleted")
-        DELETED
+        DELETED,
+
+        // These statuses are set by fixServiceStatus() if suspendDate or deleteDate are in the past.
+        /**
+         * The service is currently being suspended.
+         */
+        SUSPENDING,
+        /**
+         * The service is currently being deleted.
+         */
+        DELETING
     }
 
     private int id;
@@ -267,6 +277,8 @@ public abstract class Service {
         if (status == Status.ACTIVE) {
             refresh(); // initially load the data
         }
+
+        fixServiceStatus();
     }
 
     /**
@@ -287,5 +299,17 @@ public abstract class Service {
             }
         }
         return false;
+    }
+
+    /**
+     * Sets the status correctly if suspendDate or deleteDate are in the past.
+     */
+    private void fixServiceStatus() {
+        GregorianCalendar now = new GregorianCalendar();
+        if (deleteDate.before(now) && status != Service.Status.DELETED) {
+            status = Status.DELETING;
+        } else if (suspendDate.before(now) && status != Service.Status.SUSPENDED) {
+            status = Status.SUSPENDING;
+        }
     }
 }

--- a/src/main/java/net/nitrado/api/services/cloudservers/CloudServer.java
+++ b/src/main/java/net/nitrado/api/services/cloudservers/CloudServer.java
@@ -819,5 +819,7 @@ public class CloudServer extends Service {
         if (getStatus() == Status.ACTIVE || getStatus() == Status.SUSPENDED) {
             refresh(); // initially load the data
         }
+
+        fixServiceStatus();
     }
 }


### PR DESCRIPTION
When the user asks the NitrAPI to suspend a service, the suspendDate is set to the current time immediately. The status of the service is updated once the suspend action is finished. In this time the user can not yet delete the service.
To display this intermediate state, this adds new statuses for suspending and deleting.
They are set if suspendDate or deleteDate are in the past.