### PR TITLE
DDoS History Falscher Endpunkt

### DIFF
--- a/src/main/java/net/nitrado/api/services/gameservers/Gameserver.java
+++ b/src/main/java/net/nitrado/api/services/gameservers/Gameserver.java
@@ -664,7 +664,7 @@ public class Gameserver extends Service {
      * @see DDoSAttack
      */
     public DDoSAttack[] getDDoSHistory() throws NitrapiException {
-        JsonObject data = api.dataGet("services/" + getId() + "/gameservers/ddos", null);
+        JsonObject data = api.dataGet("services/" + getId() + "/ddos", null);
         return api.fromJson(data.get("history"), DDoSAttack[].class);
     }
 


### PR DESCRIPTION
https://doc.nitrado.net/#api-Service-DDoSHistory

URL angepasst.
Laut Doku gehört die DDoS-History zum Service und nicht zum Gameserver, ggf ist die Methode also auch in der falschen Klasse?
